### PR TITLE
Allow usage in linked modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
     "node": true
   },
   "globals": {
+    "REQUEST_LOCAL_STORAGE_VERSION": false,
     "SERVER_SIDE": false
   },
   "rules": {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -6,6 +6,7 @@ const path = require('path');
 const eslint = require('gulp-eslint');
 const replace = require("gulp-replace");
 const uglify = require("gulp-uglify");
+const packageJson = require("./package.json");
 
 gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
 
@@ -20,6 +21,7 @@ const compress = [
 const compile = server => gulp.src(["src/**/*.js"])
 	.pipe(babel())
 	.pipe(replace("SERVER_SIDE", server ? "true" : "false"))
+	.pipe(replace("REQUEST_LOCAL_STORAGE_VERSION", JSON.stringify(packageJson.version)))
 	.pipe(uglify({compress, mangle: false, output: {beautify: true}}))
 	.pipe(gulp.dest("./lib/"+(server?"server/":"browser/")));
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,4 +48,6 @@ var namespaces         = 0
 	return getter;
 }
 
-module.exports = { getNamespace, getCountNamespaces, startRequest, bind, patch };
+module.exports = global.requestLocalStorage || { getNamespace, getCountNamespaces, startRequest, bind, patch };
+
+if (!global.requestLocalStorage) global.requestLocalStorage = module.exports;

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,8 @@ var namespaces         = 0
 	return getter;
 }
 
-module.exports = global.requestLocalStorage || { getNamespace, getCountNamespaces, startRequest, bind, patch };
+global.requestLocalStorage = global.requestLocalStorage || {};
 
-if (!global.requestLocalStorage) global.requestLocalStorage = module.exports;
+module.exports = global.requestLocalStorage[REQUEST_LOCAL_STORAGE_VERSION] || { getNamespace, getCountNamespaces, startRequest, bind, patch };
+
+if (!global.requestLocalStorage[REQUEST_LOCAL_STORAGE_VERSION]) global.requestLocalStorage[REQUEST_LOCAL_STORAGE_VERSION] = module.exports;


### PR DESCRIPTION
`request-local-storage` throws `RLS() access outside of request!` when used in both a parent module and a linked module.

This PR works around the issue by adding a key to the global namespace and exporting that same key if it already exists (singleton style).

Example error / repo: karlhorky/react-server-bike-share-example#2