### PR TITLE
Replace use of obsolete Object.observe with Proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - v4
-  - v5
+  - v12

--- a/src/index.js
+++ b/src/index.js
@@ -30,19 +30,13 @@ var namespaces         = 0
 
 	// This is guarded against old versions of node that don't provide the
 	// necessary API (bamboo).
-	if (SERVER_SIDE && Object.observe) {
-
-		Object.observe(getter, changes => {
-
+	if (SERVER_SIDE && Proxy) {
+		getter = new Proxy(getter, {set: function(target, prop, value) {
 			// It's easy to make the mistake of using `RLS.foo`
 			// instead of `RLS().foo`, but this is actually a very
 			// bad error server-side.  It's a leak across requests.
-			throw new Error(`Use of "RLS.${
-				changes[0].name
-			}" should be "RLS().${
-				changes[0].name
-			}"!`);
-		});
+			throw new Error(`Use of "RLS.${prop}" should be "RLS().${prop}"!`);
+		}});
 	}
 
 	return getter;


### PR DESCRIPTION
Object.observe has been marked as obsolete. Replace its usage with Proxy instead.