### PR TITLE
Replace obsolete use of Object.observe and replace with Proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - v4
-  - v5
+  - v12

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,14 +1,10 @@
 const babel = require('gulp-babel');
 const del = require('del');
 const gulp = require('gulp');
-const nsp = require('gulp-nsp');
-const path = require('path');
 const eslint = require('gulp-eslint');
-const replace = require("gulp-replace");
-const uglify = require("gulp-uglify");
-const packageJson = require("./package.json");
-
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
+const replace = require('gulp-replace');
+const uglify = require('gulp-uglify');
+const packageJson = require('./package.json');
 
 // Don't actually want to compress, but _do_ want dead code elimination.
 const compress = [
@@ -18,28 +14,28 @@ const compress = [
 	'side_effects', 'warnings',
 ].reduce((m, v) => (m[v] = false, m), {dead_code: true});
 
-const compile = server => gulp.src(["src/**/*.js"])
+const compile = server => gulp.src(['src/**/*.js'])
 	.pipe(babel())
-	.pipe(replace("SERVER_SIDE", server ? "true" : "false"))
-	.pipe(replace("REQUEST_LOCAL_STORAGE_VERSION", JSON.stringify(packageJson.version)))
+	.pipe(replace('SERVER_SIDE', server ? 'true' : 'false'))
+	.pipe(replace('REQUEST_LOCAL_STORAGE_VERSION', JSON.stringify(packageJson.version)))
 	.pipe(uglify({compress, mangle: false, output: {beautify: true}}))
-	.pipe(gulp.dest("./lib/"+(server?"server/":"browser/")));
+	.pipe(gulp.dest('./lib/'+(server?'server/':'browser/')));
 
-gulp.task("compileBrowser", () => compile(false));
-gulp.task("compileServer",  () => compile(true ));
-gulp.task('compile', ['compileServer', 'compileBrowser']);
+gulp.task('compileBrowser', () => compile(false));
+gulp.task('compileServer',  () => compile(true ));
+gulp.task('compile', gulp.series('compileServer', 'compileBrowser'));
 
 gulp.task('clean', () => {
-	del(["lib/**/*.js", "lib"]).then(paths => {
+	del(['lib/**/*.js', 'lib']).then(paths => {
 		console.log('Deleted files and folders:\n\t'+paths.join('\n\t'))
 	})
 });
 
-gulp.task('eslint', [], () =>  gulp.src("src/**/*.js")
+gulp.task('eslint', () => gulp.src('src/**/*.js')
 	.pipe(eslint())
 	.pipe(eslint.format())
 	.pipe(eslint.failAfterError())
 );
 
-gulp.task('prepublish', ['nsp', 'compile']);
-gulp.task('test', ['eslint']);
+gulp.task('prepublish', gulp.series('compile'));
+gulp.task('test', gulp.series('eslint'));

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel": "^6.5.2",
     "babel-preset-es2015": "^6.6.0",
     "del": "^2.2.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^2.0.0",
     "gulp-nsp": "^2.3.1",


### PR DESCRIPTION
Uses Proxy instead of Object.observe to detect RLS leaks.