### PR TITLE
Remove gulp-nps task

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,14 +1,10 @@
 const babel = require('gulp-babel');
 const del = require('del');
 const gulp = require('gulp');
-const nsp = require('gulp-nsp');
-const path = require('path');
 const eslint = require('gulp-eslint');
 const replace = require("gulp-replace");
 const uglify = require("gulp-uglify");
 const packageJson = require("./package.json");
-
-gulp.task('nsp', (cb) => nsp({package: path.resolve('package.json')}, cb));
 
 // Don't actually want to compress, but _do_ want dead code elimination.
 const compress = [
@@ -41,5 +37,5 @@ gulp.task('eslint', [], () =>  gulp.src("src/**/*.js")
 	.pipe(eslint.failAfterError())
 );
 
-gulp.task('prepublish', ['nsp', 'compile']);
+gulp.task('prepublish', ['compile']);
 gulp.task('test', ['eslint']);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gulp": "^3.9.1",
     "gulp-babel": "^6.1.2",
     "gulp-eslint": "^2.0.0",
-    "gulp-nsp": "^2.3.1",
     "gulp-replace": "^0.5.4",
     "gulp-uglify": "^1.5.3"
   }


### PR DESCRIPTION
The gulp-nps task is broken because nps was removed and absorbed to run within npm 6. This PR removes the gulp-nps task.